### PR TITLE
Update CrowdinSDK.podspec

### DIFF
--- a/CrowdinSDK.podspec
+++ b/CrowdinSDK.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'CrowdinAPI' do |subspec|
     subspec.name = 'CrowdinAPI'
     subspec.source_files = 'CrowdinSDK/Classes/CrowdinAPI/**/*'
-    subspec.dependency 'Starscream', '3.0.6'
+    subspec.dependency 'Starscream', '~> 3.0.6'
     subspec.dependency 'BaseAPI', '0.1.7'
   end
   


### PR DESCRIPTION
We are running into an issue where we use Apollo/GraphQL, which requires a pod spec of 3.1.1 or higher