### PR TITLE
Reduce unnecessary computation when not using realtime update feature

### DIFF
--- a/CrowdinSDK/Classes/CrowdinSDK/Extensions/UIButton+Swizzle.swift
+++ b/CrowdinSDK/Classes/CrowdinSDK/Extensions/UIButton+Swizzle.swift
@@ -14,6 +14,13 @@ extension UIControl.State {
 
 // MARK: - UIButton extension with core functionality for language substitution.
 extension UIButton {
+    /// Whether to process and store localization keys and values
+    static var shouldProcessLocalizationKeysAndValues: Bool = {
+        // Currently, storing localization keys and values is only needed for the real-time updates feature.
+        // If that feature is not even compiled, we should not process localization keys.
+        return CrowdinSDK.responds(to: CrowdinSDK.Selectors.initializeRealtimeUpdatesFeature.rawValue)
+    }()
+
     /// Association object for storing localization keys for different states.
     private static let localizationKeyAssociation = ObjectAssociation<[UInt: String]>()
     
@@ -101,6 +108,9 @@ extension UIButton {
     ///   - title: Title string to proceed.
     ///   - state: The state that uses the specified title.
     func proceed(title: String?, for state: UIControl.State) {
+        guard Self.shouldProcessLocalizationKeysAndValues else {
+            return
+        }
         if let title = title {
             if let key = Localization.current.keyForString(title) {
                 // Try to find values for key (formated strings, plurals)

--- a/CrowdinSDK/Classes/CrowdinSDK/Extensions/UILabel+Swizzle.swift
+++ b/CrowdinSDK/Classes/CrowdinSDK/Extensions/UILabel+Swizzle.swift
@@ -10,6 +10,13 @@ import UIKit
 
 // MARK: -  extension with core functionality for language substitution.
 extension UILabel {
+    /// Whether to process and store localization keys and values
+    static var shouldProcessLocalizationKeysAndValues: Bool = {
+        // Currently, storing localization keys and values is only needed for the real-time updates feature.
+        // If that feature is not even compiled, we should not process localization keys.
+        return CrowdinSDK.responds(to: CrowdinSDK.Selectors.initializeRealtimeUpdatesFeature.rawValue)
+    }()
+
     /// Association object for storing localization key.
     private static let localizationKeyAssociation = ObjectAssociation<String>()
     
@@ -66,6 +73,9 @@ extension UILabel {
     ///
     /// - Parameter text: Title text.
     func proceed(text: String?) {
+        guard Self.shouldProcessLocalizationKeysAndValues else {
+            return
+        }
         if let text = text {
             self.localizationKey = Localization.current.keyForString(text)
             


### PR DESCRIPTION
This change shortcircuits processing that is unnecessary when the realtime-update feature is not used.

**Background**
Our app is very UI-rich, and we found that CrowdIn was using a significant amount of compute time.

After tracing through the code, it appears that the CrowdInSDK was doing a significant amount of string searching and string matching (**it was taking about 3-5% of cpu cycles on the main thread**). 

The results of this string processing was not used anywhere except for the **real-time update feature**, **a dev-only feature!**

To ensure that we don't do any of this processing when the real-time update feature is not even compiled (which is every prod build), this PR adds a short-circuit to avoid all that work within the library.

This is a pretty strong and effective band-aid. We should never do processing on data that doesn't get used at all.

**Future work**
If a feature gets added down the road that do require the localization keys and values, it would be important to figure out how to optimize the `findKey(for string: String)` function for classes conforming to `LocalizationDataSourceProtocol`. That is extremely time-intensive on an app with a lot of text.