### PR TITLE
Fix: Trimming whitespaces in the middle of a string

### DIFF
--- a/Sources/CrowdinSDK/CrowdinAPI/ContentDeliveryAPI/XMLParser/XMLParser.swift
+++ b/Sources/CrowdinSDK/CrowdinAPI/ContentDeliveryAPI/XMLParser/XMLParser.swift
@@ -169,8 +169,7 @@ extension SwiftXMLParser: XMLParserDelegate {
     }
     
     public func parser(_ parser: XMLParser, foundCharacters string: String) {
-        let append = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        textInProcess.append(append)
+        textInProcess.append(string)
     }
     
     public func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
@@ -182,8 +181,11 @@ extension SwiftXMLParser: XMLParserDelegate {
         let parent = dicStack[dicStack.endIndex - 2]
         
         if textInProcess.count > 0 {
+
+            let finishedText = textInProcess.trimmingCharacters(in: .whitespacesAndNewlines)
+
             if value.count > 0 {
-                value[TextKey] = textInProcess
+                value[TextKey] = finishedText
             } else {
                 //If the current element has only value, no Attributes, like <list> 1 </ list>
                 //Replace the dictionary directly with string
@@ -191,11 +193,11 @@ extension SwiftXMLParser: XMLParserDelegate {
                     //parent now looks like： {"list" : [1,{}]}
                     //Replace the empty dictionary with a string
                     array.removeLastObject()
-                    array.add(textInProcess)
+                    array.add(finishedText)
                 } else {
                     //parent now looks like： {"list" : {} }
                     //Replace the empty dictionary with a string
-                    parent[elementName] = textInProcess
+                    parent[elementName] = finishedText
                 }
             }
         } else {


### PR DESCRIPTION
**Change:**
Moving string trimming in XMLParser to the finished text.

**Explanation:**
`XMLParser` doesn't guarantee that it will parse an element in a single call, as it is stated in the Documentation as well

> `func parser(XMLParser, foundCharacters: String)`
> Sent by a parser object to provide its delegate with a string representing all or part of the characters of the current element.

So the original implementation could result in trimming spaces that were incorrectly assumed to be unnecessary.

**Example of the bug:**

The Slovenian translation for the string  `What is your target based on?` is `Na čem temelji vaš cilj?`.
This strings results in 2 calls to `parser(XMLParser, foundCharacters: String)` as follows:

`foundCharacters = "Na "`
`foundCharacters = "čem temelji vaš cilj?"`

Trimming the strings in that method results in:
`Načem temelji vaš cilj?`

