### PR TITLE
Fix issue with race condition after downloading localizations.

### DIFF
--- a/Sources/CrowdinSDK/Providers/Crowdin/LocalizationDownloader/CrowdinLocalizationDownloader.swift
+++ b/Sources/CrowdinSDK/Providers/Crowdin/LocalizationDownloader/CrowdinLocalizationDownloader.swift
@@ -40,6 +40,8 @@ class CrowdinLocalizationDownloader: CrowdinDownloaderProtocol {
     }
     
     func download(strings: [String], plurals: [String], xliffs: [String], jsons: [String], with hash: String, timestamp: TimeInterval?, for localization: String) {
+        self.operationQueue.cancelAllOperations()
+        
         self.contentDeliveryAPI = CrowdinContentDeliveryAPI(hash: hash, session: URLSession.shared)
         self.strings = nil
         self.plurals = nil


### PR DESCRIPTION
Closes #199

Cancel downloading of localization before starting new downloading.
It prevents calling strings/plurals setup multiple times.