### PR TITLE
build: Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "CrowdinSDK",
     platforms: [
         .macOS(.v10_13),
-        .watchOS(.v4),
+        .watchOS(.v5),
         .iOS(.v12),
         .tvOS(.v12)
     ],


### PR DESCRIPTION
Update watchOS to a minimum of .v5 due to Starscream dependency minimum.